### PR TITLE
v0.0.10

### DIFF
--- a/check-sources.ps1
+++ b/check-sources.ps1
@@ -157,8 +157,8 @@ function handleWebSource([PSObject]$source)
     # Si les filtres définis ne sont pas assez précis et que plusieurs résultats sont renvoyés,
     if($result -is [System.Array])
     {
-        $logHistory.addWarningAndDisplay("Plus d'un élément pouvant contenir l'information de trouvé. Veuillez contrôler la valeur de 'searchFilters'  dans le fichier ($($webSourcesFile)) pour ajouter plus de précision à la recherche")
-        continue
+        $logHistory.addWarningAndDisplay("Plus d'un élément pouvant contenir l'information de trouvé. C'est le premier qui a va etre pris.")
+        $result = $result[0]
     }
 
     # Tentative d'extraire la date de mise à jour à l'aide de l'expression régulière donnée dans le fichier de configuration

--- a/data/web-sources.json
+++ b/data/web-sources.json
@@ -76,7 +76,7 @@
         ],
         "dateRegex": ".*?([0-9]{2,2} [a-zA-Z]+ [0-9]{4,4}).*?",
         "actions": [
-            "Mettre à jour les données sur le calque \"Situation actuelle\" à l'aide du contenu du fichier CSV généré"
+            "Mettre à jour les données sur le tableau \"Situation actuelle\" à l'aide du contenu du fichier CSV généré"
         ],
         "textToSpeech": "Covid 19 for Switzerland web page has been updated. Please have a look at CSV generated file.",
         "callbackFunc": "extractActualSituationCH"
@@ -107,6 +107,33 @@
             "Imprimer le fichier et le glisser dans la fourre sur le panneau \"Situation actuelle de l'épidémie\""
         ],
         "textToSpeech": "InfoSAN Vaud web page has been updated",
+        "callbackFunc": ""
+    },
+    {
+        "name": "Point épidémiologique",
+        "location": "https://www.infosan.vd.ch/resultat-de-la-recherche/search/point%20%C3%A9pid%C3%A9miologique/filter0/type-publication/?tx_solr%5Bsort%5D=changed_desc%20desc",
+        "searchFilters": [
+            {
+                "attribute": "tagName",
+                "operator": "-eq",
+                "value": "div"
+            },
+            {
+                "attribute": "class",
+                "operator": "-eq",
+                "value": "tile-left"
+            },
+            {
+                "attribute": "innerHTML",
+                "operator": "-like",
+                "value": "<p>*</p>*"
+            }
+        ],
+        "dateRegex": ".*?([0-9]{2,2}\\.[0-9]{2,2}\\.[0-9]{4,4}).*?",
+        "actions":[
+            "Télécharger et imprimer le fichier Excel puis le mettre dans la fourre sur le panneau \"Situation actuelle de l'épidémie\""
+        ],
+        "textToSpeech": "Epidemiologic point updated",
         "callbackFunc": ""
     }
 

--- a/include/func.inc.ps1
+++ b/include/func.inc.ps1
@@ -22,10 +22,10 @@ function objectPropertyExists([PSCustomObject]$obj, [string]$propertyName)
 #>
 function soundAlert([System.Speech.Synthesis.SpeechSynthesizer]$speechSynthesizer, [string]$message)
 {
-    # [System.Console]::Beep(500, 100)
+    [System.Console]::Beep(500, 100)
     # [System.Console]::Beep(1000, 100)
     # [System.Console]::Beep(2000, 100)
-    # [System.Console]::Beep(1000, 100)
+    [System.Console]::Beep(1000, 100)
     [System.Console]::Beep(500, 100)
 
     $speechSynthesizer.Speak($message)


### PR DESCRIPTION
- Ajout d'une nouvelle source pour le point épidémiologique
- Signal sonor plus long avant que la voix ne dise ce qui a été mis à jour
- Tableau de résultat (lors de recherche de l'élément contenant la date) maintenant autorisés, on prend le 1er élément de la liste par défaut.